### PR TITLE
Use create_or_find_by! to avoid race conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ memory
 .rvmrc
 Gemfile.lock
 log
+.bundle
+vendor
+

--- a/lib/acts_as_follower/follower.rb
+++ b/lib/acts_as_follower/follower.rb
@@ -30,7 +30,7 @@ module ActsAsFollower #:nodoc:
       def follow(followable)
         if self != followable
           params = {followable_id: followable.id, followable_type: parent_class_name(followable)}
-          self.follows.where(params).first_or_create!
+          self.follows.create_or_find_by!(params)
         end
       end
 


### PR DESCRIPTION
Per https://github.com/thepracticaldev/dev.to/pull/8215#issuecomment-652321622 we need to use `create_or_find_by!` to actually avoid duplicates and avoid race conditions